### PR TITLE
Add an option to fire the PAS PrincipalCreated event

### DIFF
--- a/Products/AutoUserMakerPASPlugin/auth.py
+++ b/Products/AutoUserMakerPASPlugin/auth.py
@@ -22,6 +22,8 @@ from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
 from random import choice
 from ZODB.POSException import ConflictError
+from Products.PluggableAuthService.events import PrincipalCreated
+from zope.event import notify
 
 import itertools
 import re
@@ -67,6 +69,7 @@ challengeReplacementKey = 'challenge_replacement'
 challengeHeaderEnabledKey = 'challenge_header_enabled'
 challengeHeaderNameKey = 'challenge_header_name'
 defaultRolesKey = 'default_roles'
+firePASEventsKey = 'fire_pas_events'
 
 PWCHARS = string.letters + string.digits + string.punctuation
 
@@ -213,6 +216,9 @@ class AutoUserMakerPASPlugin(BasePlugin):
                 source_groups = getToolByName(self, 'source_groups')
                 for ii in groups:
                     source_groups.addPrincipalToGroup(user.getId(), ii)
+
+                if user is not None and 'principal_created' in self.getProperty(firePASEventsKey, ()):
+                    notify(PrincipalCreated(user))
         else:
             config = self.getConfig()
             if config.get(autoUpdateUserPropertiesKey, 0):
@@ -339,6 +345,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
          'challenge_pattern': 'http://(.*)',
          'challenge_replacement': 'https://\\\\1',
          'default_roles': ('Member',),
+         'fire_pas_events': (),
          'http_authz_tokens': (),
          'http_commonname': ('HTTP_SHIB_PERSON_COMMONNAME',),
          'http_country': ('HTTP_SHIB_ORGPERSON_C',),
@@ -376,6 +383,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
             (challengeReplacementKey, 'string', 'w', _defaultChallengeReplacement),
             (challengeHeaderEnabledKey, 'boolean', 'w', False),
             (challengeHeaderNameKey, 'string', 'w', ""),
+            (firePASEventsKey, 'lines', 'w', []),
             (defaultRolesKey, 'lines', 'w', ['Member']))
         # Create any missing properties
         ids = set()
@@ -416,6 +424,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
             challengeReplacementKey: self.getProperty(challengeReplacementKey),
             challengeHeaderEnabledKey: self.getProperty(challengeHeaderEnabledKey),
             challengeHeaderNameKey: self.getProperty(challengeHeaderNameKey),
+            firePASEventsKey: self.getProperty(firePASEventsKey),
             defaultRolesKey: self.getProperty(defaultRolesKey)}
 
     security.declarePublic('getSharingConfig')
@@ -764,25 +773,26 @@ class ApacheAuthPluginHandler(AutoUserMakerPASPlugin, ExtractionPlugin):
                 ii['values'] = saveVals
         # Save the form values
         self.manage_changeProperties({stripDomainNamesKey: strip,
-            stripDomainNamesListKey: reqget(stripDomainNamesListKey, ''),
-            httpRemoteUserKey: reqget(httpRemoteUserKey, ''),
-            httpCommonnameKey: reqget(httpCommonnameKey, ''),
-            httpDescriptionKey: reqget(httpDescriptionKey, ''),
-            httpEmailKey: reqget(httpEmailKey, ''),
-            httpLocalityKey: reqget(httpLocalityKey, ''),
-            httpStateKey: reqget(httpStateKey, ''),
-            httpCountryKey: reqget(httpCountryKey, ''),
-            autoUpdateUserPropertiesKey: autoupdate,
-            autoUpdateUserPropertiesIntervalKey: autoupdate_interval,
-            httpAuthzTokensKey: reqget(httpAuthzTokensKey, ''),
-            httpSharingTokensKey: reqget(httpSharingTokensKey, ''),
-            httpSharingLabelsKey: reqget(httpSharingLabelsKey, ''),
-            useCustomRedirectionKey: reqget(useCustomRedirectionKey, False),
-            challengeReplacementKey: reqget(challengeReplacementKey, ''),
-            challengePatternKey: reqget(challengePatternKey, ''),
-            challengeHeaderEnabledKey: reqget(challengeHeaderEnabledKey, False),
-            challengeHeaderNameKey: reqget(challengeHeaderNameKey, ''),
-            defaultRolesKey: reqget(defaultRolesKey, '')})
+                                      stripDomainNamesListKey: reqget(stripDomainNamesListKey, ''),
+                                      httpRemoteUserKey: reqget(httpRemoteUserKey, ''),
+                                      httpCommonnameKey: reqget(httpCommonnameKey, ''),
+                                      httpDescriptionKey: reqget(httpDescriptionKey, ''),
+                                      httpEmailKey: reqget(httpEmailKey, ''),
+                                      httpLocalityKey: reqget(httpLocalityKey, ''),
+                                      httpStateKey: reqget(httpStateKey, ''),
+                                      httpCountryKey: reqget(httpCountryKey, ''),
+                                      autoUpdateUserPropertiesKey: autoupdate,
+                                      autoUpdateUserPropertiesIntervalKey: autoupdate_interval,
+                                      httpAuthzTokensKey: reqget(httpAuthzTokensKey, ''),
+                                      httpSharingTokensKey: reqget(httpSharingTokensKey, ''),
+                                      httpSharingLabelsKey: reqget(httpSharingLabelsKey, ''),
+                                      useCustomRedirectionKey: reqget(useCustomRedirectionKey, False),
+                                      challengeReplacementKey: reqget(challengeReplacementKey, ''),
+                                      challengePatternKey: reqget(challengePatternKey, ''),
+                                      challengeHeaderEnabledKey: reqget(challengeHeaderEnabledKey, False),
+                                      challengeHeaderNameKey: reqget(challengeHeaderNameKey, ''),
+                                      firePASEventsKey: reqget(firePASEventsKey, ''),
+                                      defaultRolesKey: reqget(defaultRolesKey, '')})
         return REQUEST.RESPONSE.redirect('%s/manage_config' %
                                          self.absolute_url())
 

--- a/Products/AutoUserMakerPASPlugin/config.zpt
+++ b/Products/AutoUserMakerPASPlugin/config.zpt
@@ -252,6 +252,14 @@
                 tal:content="python:'\n'.join(config['http_sharing_labels'])">
       </textarea>
     </p>
+
+    <h3>Fire PAS Events</h3>
+    <p>
+      <input type="checkbox" name="fire_pas_events" id="fire_principal_created" value="principal_created"
+             tal:attributes="checked python:'fire_principal_created' in config['fire_pas_events'] and 'checked' or None">
+      <label for="fire_principal_created">Principal Created Event</label>
+    </p>
+
       </fieldset>
 
     <input type="submit" i18n:domain="plone"

--- a/Products/AutoUserMakerPASPlugin/tests/AutoUserMakerPASPlugin.txt
+++ b/Products/AutoUserMakerPASPlugin/tests/AutoUserMakerPASPlugin.txt
@@ -164,6 +164,7 @@ Now, let's check the default configuration:
     'challenge_pattern':http://(.*)
     'challenge_replacement':https://\1
     'default_roles':('Member',)
+    'fire_pas_events':()
     'http_authz_tokens':()
     'http_commonname':('HTTP_SHIB_PERSON_COMMONNAME',)
     'http_country':('HTTP_SHIB_ORGPERSON_C',)
@@ -197,6 +198,7 @@ pseudo REQUEST object, then get the results and print in order.
     ...                     "http_authz_tokens": 'HTTP_TEST_USER',
     ...                     "http_sharing_tokens": 'HTTP_TEST_USER',
     ...                     "http_sharing_labels": 'TEST_TITLE',
+    ...                     "fire_pas_events": 'test_event',
     ...                     "default_roles": ['Test Role']})
     >>> apache.manage_changeConfig(request)
     >>> inOrder(apache.getConfig())
@@ -207,6 +209,7 @@ pseudo REQUEST object, then get the results and print in order.
     'challenge_pattern':http://example.org(.*)
     'challenge_replacement':https://example.com/
     'default_roles':('Test Role',)
+    'fire_pas_events':('test_event',)
     'http_authz_tokens':('HTTP_TEST_USER',)
     'http_commonname':('HTTP_TEST_COMMONNAME',)
     'http_country':('HTTP_TEST_COUNTRY',)
@@ -233,6 +236,7 @@ the above output.
     'challenge_pattern':http://example.org(.*)
     'challenge_replacement':https://example.com/
     'default_roles':('Test Role',)
+    'fire_pas_events':('test_event',)
     'http_authz_tokens':('HTTP_TEST_USER',)
     'http_commonname':('HTTP_TEST_COMMONNAME',)
     'http_country':('HTTP_TEST_COUNTRY',)

--- a/Products/AutoUserMakerPASPlugin/tests/test_plugin.py
+++ b/Products/AutoUserMakerPASPlugin/tests/test_plugin.py
@@ -3,6 +3,9 @@ from Products.AutoUserMakerPASPlugin.auth import ApacheAuthPluginHandler
 from Products.AutoUserMakerPASPlugin.auth import httpEmailKey
 from Products.AutoUserMakerPASPlugin.Extensions.Install import PLUGIN_ID as pluginId
 from Products.AutoUserMakerPASPlugin.tests.base import PluginTestCase
+from zope.interface import Interface
+from Products.PluggableAuthService.interfaces.events import IPrincipalCreatedEvent
+import zope
 
 
 class AutoUserMakerPASPluginTests(PluginTestCase):
@@ -16,6 +19,31 @@ class AutoUserMakerPASPluginTests(PluginTestCase):
         auth = self.plugin.authenticateCredentials
         self.assertFalse(auth({}))
         self.assertEqual(auth({'user_id': 'foobar'}), ('foobar', 'foobar'))
+
+    def test_principal_created_event_on_off(self):
+        class CallCounter:
+            num_calls = 0
+
+            def __call__(self, context, event):
+                self.num_calls += 1
+
+        plugin = self.plugin
+        auth = plugin.authenticateCredentials
+        handler = CallCounter()
+
+        gsm = zope.component.getGlobalSiteManager()
+        gsm.registerHandler(handler, (Interface, IPrincipalCreatedEvent))
+
+        plugin._setProperty('fire_pas_events', ('principal_created',), 'lines')
+        auth({'user_id': 'foobar'})
+        self.assertEqual(1, handler.num_calls)
+
+        auth({})
+        self.assertEqual(1, handler.num_calls)
+
+        plugin._updateProperty('fire_pas_events', ())
+        auth({'user_id': 'foobar'})
+        self.assertEqual(1, handler.num_calls)
 
     def test_authentication_session(self):
         """ Test that authenticating will create a session, if configured."""


### PR DESCRIPTION
Previously the plugin could not fire the PrincipalCreated event when creating a user as creating a user manually in a PAS folder does. This commit introduces the option that the plugin fires this event when it creates a user.